### PR TITLE
Fixed the error when there are no items in the cart the cart.html page

### DIFF
--- a/src/cart/index.html
+++ b/src/cart/index.html
@@ -57,7 +57,7 @@
     <main class="divider">
       <section class="products">
         <h2>My Cart</h2>
-
+        <div id="cart-message"></div> <!-- Adding a div to show the empty cart message if the array is empty. -->
         <ul class="product-list">
           <!-- <li class="cart-card divider">
             <a href="product_pages/marmot-ajax-3.html" class="cart-card__image">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -282,3 +282,11 @@ footer {
   padding: 2px 6px;
   line-height: 1;
 }
+/***** w02 individual MG *****/
+#cart-message {
+  text-align: center;
+  font-style: italic;
+  color: #777;
+  padding: 20px 0;
+  font-size: 1.2rem;
+}

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,9 +1,17 @@
 import { CARTKEY, getLocalStorage, updateCartBadge } from "./utils.mjs";
 
 function renderCartContents() {
-  const cartItems = getLocalStorage(CARTKEY);
+  const cartItems = getLocalStorage(CARTKEY) || [];//Starting an empty array in case the local storage key is null to avoid the error: cart.js:5 Uncaught TypeError: Cannot read properties of null (reading 'map').
+  const cartMessage = document.getElementById("cart-message");
+  if(cartItems.length === 0){ 
+      cartMessage.textContent = "Your cart is empty."; //If the cart is empty, Show a message.
+      document.querySelector(".product-list").innerHTML = ""; // clear list
+      return; // stop further processing
+    } 
+  cartMessage.textContent = "";  
   const htmlItems = cartItems.map((item) => cartItemTemplate(item));
   document.querySelector(".product-list").innerHTML = htmlItems.join("");
+  
   updateCartBadge();
 }
 


### PR DESCRIPTION
Starting an empty array in case the "so-cart" key is empty to prevent the map errors when the cart is empty. Added a message to show the user the cart is empty when there are no items.